### PR TITLE
Comment out privateRepo-related fetch logic for testing

### DIFF
--- a/app/api/github/languages/route.ts
+++ b/app/api/github/languages/route.ts
@@ -5,18 +5,9 @@ const octokit = new Octokit({
   auth: process.env.GITHUB_TOKEN,
 });
 
-// const privateOctokit = new Octokit({
-//   auth: process.env.PRIVATE_GITHUB_TOKEN,
-// });
-
 export async function GET() {
   try {
     const reposResponse = await octokit.request('GET /user/repos?page=1&per_page=1000', { type: 'owner' });
-
-    // const privateRepo = await privateOctokit.request('GET /repos/blissfulsaint/htdocs/languages', {
-    //   owner: 'blissfulsaint',
-    //   repo: 'htdocs',
-    // })
     
     const repos = reposResponse.data;
 
@@ -36,13 +27,6 @@ export async function GET() {
         languageTotals[language] = (languageTotals[language] || 0) + estimatedLines;
       }
     }
-
-    // *** This implementation needs improvement in the future, it will suffice for now ***
-    // for (const [language, bytes] of Object.entries(privateRepo.data)) {
-    //   // Estimate lines of code (~60 bytes per line)
-    //   const estimatedLines = Math.round((bytes as number) / 60);
-    //   languageTotals[language] = (languageTotals[language] || 0) + estimatedLines;
-    // }
 
     return NextResponse.json(languageTotals);
   } catch (error) {

--- a/app/api/github/languages/route.ts
+++ b/app/api/github/languages/route.ts
@@ -5,18 +5,18 @@ const octokit = new Octokit({
   auth: process.env.GITHUB_TOKEN,
 });
 
-const privateOctokit = new Octokit({
-  auth: process.env.PRIVATE_GITHUB_TOKEN,
-});
+// const privateOctokit = new Octokit({
+//   auth: process.env.PRIVATE_GITHUB_TOKEN,
+// });
 
 export async function GET() {
   try {
     const reposResponse = await octokit.request('GET /user/repos?page=1&per_page=1000', { type: 'owner' });
 
-    const privateRepo = await privateOctokit.request('GET /repos/blissfulsaint/htdocs/languages', {
-      owner: 'blissfulsaint',
-      repo: 'htdocs',
-    })
+    // const privateRepo = await privateOctokit.request('GET /repos/blissfulsaint/htdocs/languages', {
+    //   owner: 'blissfulsaint',
+    //   repo: 'htdocs',
+    // })
     
     const repos = reposResponse.data;
 
@@ -38,11 +38,11 @@ export async function GET() {
     }
 
     // *** This implementation needs improvement in the future, it will suffice for now ***
-    for (const [language, bytes] of Object.entries(privateRepo.data)) {
-      // Estimate lines of code (~60 bytes per line)
-      const estimatedLines = Math.round((bytes as number) / 60);
-      languageTotals[language] = (languageTotals[language] || 0) + estimatedLines;
-    }
+    // for (const [language, bytes] of Object.entries(privateRepo.data)) {
+    //   // Estimate lines of code (~60 bytes per line)
+    //   const estimatedLines = Math.round((bytes as number) / 60);
+    //   languageTotals[language] = (languageTotals[language] || 0) + estimatedLines;
+    // }
 
     return NextResponse.json(languageTotals);
   } catch (error) {


### PR DESCRIPTION
Make the following changes:
- Remove fetching logic related to isolating a specifc private repository due to issue in production

### Background
An anomaly in the logic for fetching language statistics from GitHub API caused a then unknown issue that persisted to production due to issues with localhost not being able to fetch the correct data from the API. Upon viewing the production version of the page, the bar graph looked like this:
![before](https://github.com/user-attachments/assets/62f6b352-9c11-4de8-aa69-5f3205e91fd7)
The issue with this was that the PHP stat, along with a few of the other stats, were doubled or increased significantly from their actual values. Following is the correct info:
![after](https://github.com/user-attachments/assets/d5f8ecf9-7a85-4213-85fd-2ec1a161c9a9)
This was a result of a workaround designed to specifically target one or more private repositories due to the fact that the API route created to fetch the repo information was not fetching any info from private repositories no matter what attempts were made to expose them using GitHub tokens. The workaround directly targeted the desired private repos and added the data to the array in the backend. 

Upon pushing to production, it was discovered that the original logic for fetching all of the repository language data was suddenly able to access private repositories as well. This as well as the fact that the original logic targeting the private repos was still intact resulted in certain statistics doubling or otherwise displaying inaccurately.

It is still not known why the fetch logic is unable to get private repo data in local host and is able to in production. This will be looked into as time goes on.

For reference, this is the data in localhost (using the same code and environment variables as in production):
![localhost](https://github.com/user-attachments/assets/8ca58be7-a595-43a7-84a5-4e1e521297d9)
